### PR TITLE
Add -fix flag for automatically fixing the pinentry symlink

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,9 @@ brews:
     homepage: "https://github.com/jorgelbg/pinentry-touchid"
 
     caveats: |
+      ➡️  Ensure that pinentry-mac is the default pinentry program:
+            #{bin}/pinentry-touchid -fix
+
       ✅  Add the following line to your ~/.gnupg/gpg-agent.conf file:
             pinentry-program #{bin}/pinentry-touchid
 
@@ -52,9 +55,6 @@ brews:
 
     install: |
       bin.install "pinentry-touchid"
-
-    test: |
-      system "#{bin}/pinentry-touchid -check"
 
 archives:
 - replacements:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ $ alias pinentry='pinentry-mac'
 
 _Then try again whether you see a GUI prompt._
 
+In some cases aliasing `pinentry` to `pinentry-mac` is not enough because `gpgconf` which return the
+absolute path that points to the `$HOMEBREW_PREFIX/opt`. In that case you can execute:
+
+```sh
+$ pinentry-touchid -fix
+```
+
 ### Homebrew
 
 
@@ -77,11 +84,14 @@ Homebrew will print the next steps, which will look similar to:
 
 ```
 ==> Caveats
+➡️  Ensure that pinentry-mac is the default pinentry program:
+      /usr/local/bin/pinentry-touchid -fix
+
 ✅ Add the following line to your ~/.gnupg/gpg-agent.conf file:
       pinentry-program /usr/local/opt/pinentry-touchid/bin/pinentry-touchid
 
 🔄  Then reload your gpg-agent:
-    gpg-connect-agent reloadagent /bye
+      gpg-connect-agent reloadagent /bye
 
 🔑  Run the following command to disable "Save in Keychain" in pinentry-mac:
     defaults write org.gpgtools.common DisableKeychain -bool yes
@@ -105,6 +115,18 @@ $ pinentry-program /usr/local/bin/pinentry-touchid
 ```
 
 You can replace `/usr/local/bin/pinentry-touchid` with the path where the binary was stored.
+
+Make sure that the `pinentry-mac` is configured to be the default `pinentry` program (will be used
+as fallback). You can check which PIN program will be used by default by executing:
+
+```sh
+$ pinentry-touchid -check
+```
+
+If any error is reported `pinentry-touchid` can automatically fix the symlink for you:
+```sh
+$ pinentry-touchid -fix
+```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ $ alias pinentry='pinentry-mac'
 
 _Then try again whether you see a GUI prompt._
 
-In some cases aliasing `pinentry` to `pinentry-mac` is not enough because `gpgconf` which return the
-absolute path that points to the `$HOMEBREW_PREFIX/opt`. In that case you can execute:
+In some cases aliasing `pinentry` to `pinentry-mac` is not enough because `gpgconf` returns the
+absolute path that points to the `$HOMEBREW_PREFIX/opt` path. In that case you can execute the
+following command to automatically fix the symlink.
 
 ```sh
 $ pinentry-touchid -fix

--- a/main.go
+++ b/main.go
@@ -53,7 +53,8 @@ var (
 	errEmptyResults    = errors.New("no matching entry was found")
 	errMultipleMatches = errors.New("multiple entries matched the query")
 
-	check = flag.Bool("check", false, "Verify that pinentry-mac is present in the system")
+	check      = flag.Bool("check", false, "Verify that pinentry-mac is present in the system.")
+	fixSymlink = flag.Bool("fix", false, "Set up pinentry-mac as the fallback PIN entry program.")
 )
 
 // checkEntryInKeychain executes a search in the current keychain. The search configured to not
@@ -328,6 +329,59 @@ func GetPIN(authFn AuthFunc, promptFn PromptFunc, logger *log.Logger) GetPinFunc
 	}
 }
 
+// validatePINBinary validates that the pinentry program returned by gpgconf
+// is/points to pinentry-mac
+func validatePINBinary() (string, error) {
+	binaryPath := pinentryBinary.GetBinary()
+	originalPath := binaryPath
+	if _, err := exec.LookPath(binaryPath); err != nil {
+		return binaryPath, errors.New("PIN entry program not found")
+	}
+
+	// check if the binary is (or resolves to -- if it is a symlink) to pinentry-mac
+	info, err := os.Lstat(binaryPath)
+	if err != nil {
+		return binaryPath, fmt.Errorf("Couldn't lstat file: %w", err)
+	}
+
+	if info.Mode()&fs.ModeSymlink != 0 {
+		// the file is a symlink so we check that the resolved path contains
+		// pinentry-mac
+		path, err := filepath.EvalSymlinks(binaryPath)
+		if err != nil {
+			return binaryPath, fmt.Errorf("Couldn't resolve symlink: %w", err)
+		}
+
+		binaryPath = path
+	}
+	if !strings.Contains(binaryPath, "pinentry-mac") {
+		return "", errors.New(
+			fmt.Sprintf("%s is a symlink that resolves to %s not to pinentry-mac",
+				originalPath, binaryPath))
+	}
+
+	return binaryPath, nil
+}
+
+// fixPINBinary forces pinentry-mac as the fallback pinentry program
+func fixPINBinary(oldPath string) error {
+	newPath, err := exec.LookPath("pinentry-mac")
+	if err != nil {
+		return errors.New("pinentry-mac couldn't be found in your PATH")
+	}
+
+	if err := os.Remove(oldPath); err != nil {
+		return fmt.Errorf("Unable to remove symlink: %w", err)
+	}
+
+	// create the new symlink pointing to pinentry-mac
+	if err := os.Symlink(newPath, oldPath); err != nil {
+		return fmt.Errorf("Unable to symlink to pinentry-mac: %w", err)
+	}
+
+	return nil
+}
+
 func main() {
 	flag.Parse()
 	if !sensor.IsTouchIDAvailable() {
@@ -336,39 +390,28 @@ func main() {
 		os.Exit(-1)
 	}
 
+	if *fixSymlink {
+		path := pinentryBinary.GetBinary()
+		if err := fixPINBinary(path); err != nil {
+			fmt.Fprintf(os.Stderr, "%v %s\n", emoji.CrossMark, err)
+			os.Exit(-1)
+		}
+
+		fmt.Fprintf(os.Stderr, "%v %s is now pointing to pinentry-mac\n", emoji.CheckMarkButton, path)
+		os.Exit(0)
+	}
+
 	if *check {
-		var err error
-		binaryPath := pinentryBinary.GetBinary()
-		if binaryPath, err = exec.LookPath(binaryPath); err != nil {
-			fmt.Fprintf(os.Stderr, "PIN entry program %q not found!\n", binaryPath)
-			os.Exit(-1)
-		}
-
-		// check if the binary is (or resolves to -- if it is a symlink) to pinentry-mac
-		info, err := os.Lstat(binaryPath)
+		path, err := validatePINBinary()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Couldn't lstat file in: %s\n", binaryPath)
+			fmt.Fprintf(os.Stderr, "%v %s %s\n", emoji.CrossMark, err, path)
 			os.Exit(-1)
 		}
 
-		if info.Mode()&fs.ModeSymlink != 0 {
-			fmt.Printf("%v found symlink .... %s\n", emoji.MagnifyingGlassTiltedRight, binaryPath)
-
-			path, err := filepath.EvalSymlinks(binaryPath)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Couldn't resolve symlink in %s, error: %s", binaryPath, err)
-				os.Exit(-1)
-			}
-
-			if !strings.Contains(path, "pinentry-mac") {
-				fmt.Fprintf(os.Stderr, "%v %s is a symlink that resolves to:\n   %s -- not to pinentry-mac\n",
-					emoji.CrossMark, binaryPath, path)
-				os.Exit(-1)
-			}
+		if path != "" {
+			fmt.Fprintf(os.Stdout, "%v %s will be used as a fallback PIN program\n", emoji.CheckMarkButton, path)
 		}
 
-		fmt.Printf("%v %s fallback pinentry found\n", emoji.CheckMarkButton, pinentryBinary.GetBinary())
-		fmt.Printf("%v Looks good!\n", emoji.CheckMarkButton)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
When installing gnupg, homebrew automatically configures the path of the pinentry binary to the [`opt_bin` path of the formula instead of the symlink in `/usr/local/bin`](https://github.com/Homebrew/homebrew-core/blob/08d0d1cc331d570a31d5ef89e695ad283c75d4f6/Formula/gnupg.rb#L54) this means that actual path returned by `gpgconf` ends  up looking like: `/usr/local/opt/pinentry/bin/pinentry`.

Fixing the symlink in `/usr/local/bin` doesn't always solve the issue because `gpgconf` is still reporting the `/usr/local/opt` path.

The new flag will automatically change this symlink to point to pinentry-mac.

I tried unsuccessfully to include this as part of the automatic Formula installation but it is not possible because during installation the formula cannot modify any external path.