### PR TITLE
Allow for 18 chars long keys

### DIFF
--- a/main.go
+++ b/main.go
@@ -246,7 +246,7 @@ func GetPIN(authFn AuthFunc, promptFn PromptFunc, logger *log.Logger) GetPinFunc
 
 		matches = keyIDRegex.FindStringSubmatch(s.Desc)
 		keyID := matches[1]
-		if len(keyID) != 8 && len(keyID) != 16 {
+		if len(keyID) != 8 && len(keyID) != 16 && len(keyID) != 18 {
 			logger.Printf("Invalid keyID: %s", keyID)
 			return "", assuanError(fmt.Errorf("invalid keyID: %s", keyID))
 		}


### PR DESCRIPTION
My key's ID has the following format: 0x123456789ABCDEF0 (I'm using rsa4096). When trying to use it with pinentry-touchid, it fails and prints `Invalid keyID: 0x123456789ABCDEF0` to `/tmp/pinentry-touchid.log`.
I added code allowing for 18-chars long keys and compiled it locally, and it works perfectly fine.