### PR TITLE
fix issue with "end of file"

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ var (
 
 	check      = flag.Bool("check", false, "Verify that pinentry-mac is present in the system.")
 	fixSymlink = flag.Bool("fix", false, "Set up pinentry-mac as the fallback PIN entry program.")
+	_          = flag.String("display", "", "Set the X display (unused)")
 )
 
 // checkEntryInKeychain executes a search in the current keychain. The search configured to not


### PR DESCRIPTION
Detailed issue:

`can't connect to the PIN entry module '/opt/homebrew/opt/pinentry-touchid/bin/pinentry-touchid': End of file`

Reason:

dig into the issue find out when gpg calls out to pinentry-touchi binary, it adds "--display /private/tmp/com.apple.launchd.MGdSfNPjrJ/org.xquartz:0" flag. 

Because --display is an unrecognized flag for the binary, it errors out immediately. This then result in an unclear message returned from gpg: "No pinentry".

Fix:

adding the dummy --dispaly flag to the flag parser.