### PR TITLE
feat: fallback to pinentry-mac if no touchID

### DIFF
--- a/go-assuan/pinentry/client.go
+++ b/go-assuan/pinentry/client.go
@@ -129,14 +129,28 @@ func (c *Client) Apply(s Settings) {
 
 // GetPIN shows window with password textbox, Cancel and Ok buttons.
 // Error is returned if Cancel is pressed.
-func (c *Client) GetPIN() (string, error) {
+func (c *Client) GetPIN(s Settings) (string, *common.Error) {
 	if c.qualityBar {
-		return c.getPINWithQualBar()
+		pin, err := c.getPINWithQualBar()
+		if err != nil {
+			return "", &common.Error{
+				Src:     common.ErrSrcPinentry,
+				SrcName: "pinentry",
+				Code:    common.ErrCanceled,
+				Message: err.Error(),
+			}
+		}
+		return pin, nil
 	}
 
 	dat, err := c.Session.SimpleCmd("GETPIN", "")
 	if err != nil {
-		return "", err
+		return "", &common.Error{
+			Src:     common.ErrSrcPinentry,
+			SrcName: "pinentry",
+			Code:    common.ErrCanceled,
+			Message: err.Error(),
+		}
 	}
 	return string(dat), nil
 }
@@ -193,12 +207,21 @@ func (c *Client) getPINWithQualBar() (string, error) {
 
 // Confirm shows window with Cancel and Ok buttons but without password
 // textbox, error is returned if Cancel is pressed (as usual).
-func (c *Client) Confirm() error {
+func (c *Client) Confirm(s Settings) (bool, *common.Error) {
 	_, err := c.Session.SimpleCmd("CONFIRM", "")
-	return err
+	if err != nil {
+		return false, &common.Error{
+			Src:     common.ErrSrcPinentry,
+			SrcName: "pinentry",
+			Code:    common.ErrCanceled,
+			Message: err.Error(),
+		}
+	}
+	return true, nil
 }
 
 // Message just shows window with only OK button.
-func (c *Client) Message() {
+func (c *Client) Message(s Settings) *common.Error {
 	c.Session.SimpleCmd("MESSAGE", "")
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -392,9 +392,21 @@ func fixPINBinary(oldPath string) error {
 func main() {
 	flag.Parse()
 	if !sensor.IsTouchIDAvailable() {
-		fmt.Fprintf(os.Stderr,
-			"%v pinentry-touchid does not support devices without a Touch ID sensor!\n", emoji.CrossMark)
-		os.Exit(-1)
+		client, err := pinentry.LaunchCustom("pinentry-mac")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Pinentry Launch returned error: %v\n", err)
+			os.Exit(-1)
+		}
+		callbacks := pinentry.Callbacks{
+			GetPIN:  client.GetPIN,
+			Confirm: client.Confirm,
+			Msg:     client.Message,
+		}
+
+		if err := pinentry.Serve(callbacks, "Hi from pinentry-mac!"); err != nil {
+			fmt.Fprintf(os.Stderr, "Pinentry Serve returned error: %v\n", err)
+			os.Exit(-1)
+		}
 	}
 
 	if *fixSymlink {


### PR DESCRIPTION
There might be a situation when device has TouchID, but once the lid is closed `sensor.IsTouchIDAvailable()` returns false.
It happens when you connect and external display to your laptop and have the lid closed.

This PR adds a fallback scenario to call pinentry-mac when touchID is not available.