### PR TITLE
Add support for "Use Password..." option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ macOS keychain.
 This program interacts with the `gpg-agent` for providing a password, using the following rules:
 
 - If the password entry for the given key cannot be found in the Keychain we fallback to the
-  `pinentry-mac` program to get the password. We recommend preventing `pinentry-mac` from storing the
+  `pinentry-mac` program to get the password. We *strongly* recommend preventing `pinentry-mac` from storing the
   password: uncheck the <kbd>Save in keychain</kbd> checkbox in the dialog.
 
 - If a password entry is found the user will be shown the Touch ID dialog and upon successful

--- a/go-touchid/go.mod
+++ b/go-touchid/go.mod
@@ -1,0 +1,3 @@
+module github.com/lox/go-touchid
+
+go 1.16

--- a/go-touchid/touchid.go
+++ b/go-touchid/touchid.go
@@ -1,0 +1,60 @@
+package touchid
+
+// Forked from: https://github.com/lox/go-touchid
+// Commit 619cc8e578d0ef916aa29c806117c370f9d621cb
+// Unknown license.
+
+/*
+#cgo CFLAGS: -x objective-c -fmodules -fblocks
+#cgo LDFLAGS: -framework CoreFoundation -framework LocalAuthentication -framework Foundation
+#include <stdlib.h>
+#include <stdio.h>
+#import <LocalAuthentication/LocalAuthentication.h>
+
+int Authenticate(char const* reason) {
+  LAContext *myContext = [[LAContext alloc] init];
+  NSError *authError = nil;
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  NSString *nsReason = [NSString stringWithUTF8String:reason];
+  __block int result = 0;
+
+  if ([myContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&authError]) {
+    [myContext evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+      localizedReason:nsReason
+      reply:^(BOOL success, NSError *error) {
+        if (success) {
+          result = 1;
+        } else {
+          result = 2;
+        }
+        dispatch_semaphore_signal(sema);
+      }];
+  }
+
+  dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+  dispatch_release(sema);
+  return result;
+}
+*/
+import (
+	"C"
+)
+import (
+	"errors"
+	"unsafe"
+)
+
+func Authenticate(reason string) (bool, error) {
+	reasonStr := C.CString(reason)
+	defer C.free(unsafe.Pointer(reasonStr))
+
+	result := C.Authenticate(reasonStr)
+	switch result {
+	case 1:
+		return true, nil
+	case 2:
+		return false, nil
+	}
+
+	return false, errors.New("Error occurred accessing biometrics")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jorgelbg/pinentry-touchid
 go 1.16
 
 replace github.com/foxcpp/go-assuan => ./go-assuan
+replace github.com/lox/go-touchid => ./go-touchid
 
 require (
 	github.com/enescakir/emoji v1.0.0 // indirect

--- a/main.go
+++ b/main.go
@@ -212,11 +212,16 @@ func passwordPrompt(s pinentry.Settings) ([]byte, error) {
 }
 
 func assuanError(err error) *common.Error {
+	var message = "Unspecified error"
+	if err != nil {
+		message = err.Error()
+	}
+
 	return &common.Error{
 		Src:     common.ErrSrcPinentry,
 		SrcName: "pinentry",
 		Code:    common.ErrCanceled,
-		Message: err.Error(),
+		Message: message,
 	}
 }
 

--- a/pinentry_test.go
+++ b/pinentry_test.go
@@ -106,8 +106,8 @@ func TestGetPINUnsuccessfulAuthentication(t *testing.T) {
 	fn := GetPIN(failedAuthFn, dummyPrompt, logger)
 	pass, pinErr := fn(params)
 
-	if pinErr != nil {
-		t.Fatalf("call to GetPIN should succeed: %s", pinErr)
+	if pinErr == nil {
+		t.Fatalf("call to GetPIN should not succeed: %s", pinErr)
 	}
 
 	if pass != emptyPassword {


### PR DESCRIPTION
This series of commits adds support for detecting why TouchID authentication fails, as well as falling back to using `pinentry-mac` if the user selects the "Use Password..." option in the TouchID authentication prompt. If the user cancels the authentication, an empty password will be returned.

**An important note to mention as part of this:**

If `pinentry-mac` saved a passphrase in the keychain and the user chooses to use the "Use Password" fallback, `pinentry-mac` will read the passphrase from the keychain. If `pinentry-mac` was given the "Always allow" option, this means that returns the passphrase without prompting the user for any kind of password&mdash;which is a trivial way to bypass authentication entirely.

While I would argue that problem is more of a user-configuration problem than a problem with `pinentry-touchid` (since anyone with shell access could just replace the `pinentry-program` line in `gpg-agent.conf` with `pinentry-mac` to achieve the same thing), it's probably something worth mentioning regardless.