### PR TITLE
Clarify why “Save in keychain” MUST be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,16 @@ macOS keychain.
 This program interacts with the `gpg-agent` for providing a password, using the following rules:
 
 - If the password entry for the given key cannot be found in the Keychain we fallback to the
-  `pinentry-mac` program to get the password. We recommend preventing `pinentry-mac` from storing the
-  password: uncheck the <kbd>Save in keychain</kbd> checkbox in the dialog.
+  `pinentry-mac` program to get the password. If you have multiple keypairs with the same email which
+  you distinguish with the comment field, <strong>you MUST uncheck the <kbd>Save in keychain</kbd>
+  checkbox in the `pinentry-mac`-powered fallback dialog</strong>. `pinentry-touchid` will still
+  save to the keychain, so don't worry about that.
+
+  The problem is that `pinentry-touchid` searches by email and comment, but `pinentry-mac` doesn't
+  save the comment, so when `pinentry-touchid` fails to find the entry in the keychain, it tries to
+  create it with the comment, but since it's just creating it for the same keypair, it results in a
+  “Duplicated entry in the keychain” error in its logs, but a confusing error message from GPG,
+  without an authentication prompt.
 
 - If a password entry is found the user will be shown the Touch ID dialog and upon successful
   authentication the password stored from the keychain will be returned to the gpg-agent.


### PR DESCRIPTION
This fixes some language in the README.

- Unchecking “Save in keychain” is not merely a recommendation, it's a MUST for certain workflows.
- Explain for _what_ workflows not following this advice breaks `pinentry-touchid`, _how_, and _why_, allowing people to make a more informed choice, instead of just thinking, “why would I disable saving to the keychain?, that's what I want”.
- Clarify that “Save in keychain” still saves the entry to the keychain, just not by `pinentry-mac`, but by `pinentry-touchid`; more people will adhere to this “recommendation” if they realise it's merely a formality, and they're not _actually_ giving up saving the entry to the Keychain.

With these three changes, I reckon most people will at least manually disable the checkbox every time they create a new entry for a new keypair, which may still result in some people forgetting when they renew their keypairs some years later, but it's better than the status quo.

Also, most people might still `defaults write` to make that the default, as even if they switch back to `pinentry-mac`, having to constantly enable that checkbox is better than causing a subtle breakage if they stick with `pinentry-touchid` that causes them to be unable to decrypt files and thinking their key is broken or something.

---

Honestly, this is just another reason to switch away from `pinentry-mac` at this point. It's a dead project, it creates work for the user — having to ensure the presence and right target of a symlink, having to remember this <kbd>Save in keychain</kbd> business, etc — and it kinda locks us in to its decisions.

At least a better fix for this particular issue might simply be to save the keypair without the comment, as the ID is still in the title, but that's a bit of a loss, so even better would be to search both with and without the comment before creating a new entry.