### PR TITLE
feat: Add GnuPG 2.4+ compatibility and fix keychain permission issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist/
 
 # local binary
 pinentry
+pinentry-touchid

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,11 +21,11 @@ builds:
 brews:
   -
     tap:
-      owner: jorgelbg
+      owner: lujstn
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 
-    homepage: "https://github.com/jorgelbg/pinentry-touchid"
+    homepage: "https://github.com/lujstn/pinentry-touchid"
 
     caveats: |
       ➡️  Ensure that pinentry-mac is the default pinentry program:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,11 +23,11 @@ builds:
 brews:
   -
     repository:
-      owner: lujstn
+      owner: jorgelbg
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 
-    homepage: "https://github.com/lujstn/pinentry-touchid"
+    homepage: "https://github.com/jorgelbg/pinentry-touchid"
 
     caveats: |
       ➡️  Ensure that pinentry-mac is the default pinentry program:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: pinentry-touchid
 
 before:
@@ -20,7 +22,7 @@ builds:
 # Generate/update a homebrew formula
 brews:
   -
-    tap:
+    repository:
       owner: lujstn
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
@@ -57,8 +59,7 @@ brews:
       bin.install "pinentry-touchid"
 
 archives:
-- replacements:
-    darwin: macos
+- name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: 'checksums.txt'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 # pinentry-touchid
 
+> **🚀 This fork includes critical fixes for GnuPG 2.4+ compatibility**
+>
+> These fixes resolve errors including "error: gpg failed to sign the data", "failed to unprotect the secret key: Operation cancelled", and "You may want to update to a newer pinentry".
+>
+> Key changes:
+> - ✅ **GETINFO support** - Implements `GETINFO flavor/version/pid/ttyinfo` commands required by GnuPG 2.4+
+> - ✅ **Keychain permission handling** - Properly handles macOS keychain access permissions for entries created by pinentry-mac
+> - ✅ **Name parsing fix** - Correctly strips GPG key comments to match existing keychain entries
+> - ✅ **Duplicate entry handling** - Gracefully handles duplicate keychain entries instead of failing
+>
+
 <p align="center">
     <img class="center" src="https://user-images.githubusercontent.com/1291846/127916161-5803ca98-c0a2-4d1f-8479-860f4d7edc98.png" width="300" alt="pinentry-touchid logo"/>
 </p>
 
 Custom GPG pinentry program for macOS that allows using Touch ID for fetching the password from the
 macOS keychain.
+
+> **Compatible with GnuPG 2.4+** - This version includes support for the GETINFO commands required by modern GnuPG versions.
 
 > Macbook Pro devices without Touch ID are currently not supported. These devices > lack a Touch ID
 > sensor and while the alternative offered by Apple is to use (if available) an Apple Watch, this

--- a/README.md
+++ b/README.md
@@ -1,27 +1,5 @@
 # pinentry-touchid
 
-> **🚀 This fork includes critical fixes for GnuPG 2.4+ compatibility**
->
-> These fixes resolve errors including "error: gpg failed to sign the data", "failed to unprotect the secret key: Operation cancelled", and "You may want to update to a newer pinentry".
->
-> **📦 Installation via Homebrew:**
-> ```bash
-> # Install from my tap (recommended)
-> brew tap lujstn/tap
-> brew install pinentry-touchid
-> 
-> # Configure gpg-agent
-> echo "pinentry-program $(brew --prefix)/opt/pinentry-touchid/bin/pinentry-touchid" >> ~/.gnupg/gpg-agent.conf
-> gpgconf --kill gpg-agent
-> ```
->
-> Key changes:
-> - ✅ **GETINFO support** - Implements `GETINFO flavor/version/pid/ttyinfo` commands required by GnuPG 2.4+
-> - ✅ **Keychain permission handling** - Properly handles macOS keychain access permissions for entries created by pinentry-mac
-> - ✅ **Name parsing fix** - Correctly strips GPG key comments to match existing keychain entries
-> - ✅ **Duplicate entry handling** - Gracefully handles duplicate keychain entries instead of failing
->
-
 <p align="center">
     <img class="center" src="https://user-images.githubusercontent.com/1291846/127916161-5803ca98-c0a2-4d1f-8479-860f4d7edc98.png" width="300" alt="pinentry-touchid logo"/>
 </p>
@@ -29,7 +7,7 @@
 Custom GPG pinentry program for macOS that allows using Touch ID for fetching the password from the
 macOS keychain.
 
-> **Compatible with GnuPG 2.4+** - This version includes support for the GETINFO commands required by modern GnuPG versions.
+> **Update (2026-02-20): Now fully compatible with GnuPG 2.4+** - This version includes support for the GETINFO commands required by modern GnuPG versions.
 
 > Macbook Pro devices without Touch ID are currently not supported. These devices > lack a Touch ID
 > sensor and while the alternative offered by Apple is to use (if available) an Apple Watch, this
@@ -235,13 +213,21 @@ new one.
 
 ## Tested on
 
-I've tested `pinentry-touchid` in the following combinations of devices and macOS versions:
+`pinentry-touchid` has been tested on the following combinations of devices and macOS versions:
 
 * MacBook Pro (15-inch, 2018), macOS Catalina - 10.15.7
 * MacBook Pro (15-inch, 2018), macOS Big Sur - 11.4, 11.5.0, 11.5.1
 * MacBook Pro (16-inch, Late 2019), macOS Big Sur - 11.4, 11.5.1
 * MacBook Pro (16-inch, Late 2021), macOS Monterey - 12.2
+* MacBook Pro (16-inch, 2023), macOS Sequoia - 15.7.2
+* MacBook Pro (16-inch, 2023), macOS Tahoe - 26.2
+* MacBook Pro (16-inch, 2024), macOS Tahoe - 26.2
 
 ## Links
 
 * The project icon is taken from <a href="https://icons8.com/icon/BebbEec6QUjh/touch-id">Touch ID icon by Icons8</a>.
+
+## Credits
+
+Built by [Jorge Luis Betancourt (@jorgelbg)](https://github.com/jorgelbg), and rebuilt for GnuPG 2.4 by [Lucas Johnston Kurilov (@lujstn)](https://github.com/lujstn).
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 >
 > These fixes resolve errors including "error: gpg failed to sign the data", "failed to unprotect the secret key: Operation cancelled", and "You may want to update to a newer pinentry".
 >
+> **📦 Installation via Homebrew:**
+> ```bash
+> # Install from my tap (recommended)
+> brew tap lujstn/tap
+> brew install pinentry-touchid
+> 
+> # Configure gpg-agent
+> echo "pinentry-program $(brew --prefix)/opt/pinentry-touchid/bin/pinentry-touchid" >> ~/.gnupg/gpg-agent.conf
+> gpgconf --kill gpg-agent
+> ```
+>
 > Key changes:
 > - ✅ **GETINFO support** - Implements `GETINFO flavor/version/pid/ttyinfo` commands required by GnuPG 2.4+
 > - ✅ **Keychain permission handling** - Properly handles macOS keychain access permissions for entries created by pinentry-mac

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jorgelbg/pinentry-touchid
+module github.com/lujstn/pinentry-touchid
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lujstn/pinentry-touchid
+module github.com/jorgelbg/pinentry-touchid
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -18,11 +18,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/enescakir/emoji"
 	"github.com/foxcpp/go-assuan/common"
 	"github.com/foxcpp/go-assuan/pinentry"
+	"github.com/foxcpp/go-assuan/server"
 	pinentryBinary "github.com/gopasspw/pinentry"
 	"github.com/jorgelbg/pinentry-touchid/sensor"
 	"github.com/keybase/go-keychain"
@@ -44,6 +46,9 @@ const (
 	DefaultLogFilename = "pinentry-touchid.log"
 	defaultLoggerFlags = log.Ldate | log.Ltime | log.Lshortfile
 )
+
+// version is filled by -ldflags "-X main.version=$(git describe --tags)"
+var version = "devel"
 
 var (
 	// DefaultLogLocation is the location of the log file
@@ -84,6 +89,32 @@ func checkEntryInKeychain(label string) (bool, error) {
 	}
 
 	return len(results) == 1, nil
+}
+
+// ensureKeychainAccess attempts to access the keychain entry to trigger the macOS permission
+// dialog if needed. It doesn't return the actual password data.
+func ensureKeychainAccess(label string, logger *log.Logger) error {
+	query := keychain.NewItem()
+	query.SetSecClass(keychain.SecClassGenericPassword)
+	query.SetLabel(label)
+	query.SetMatchLimit(keychain.MatchLimitOne)
+	query.SetReturnData(false)
+	query.SetReturnAttributes(true)
+	query.SetReturnRef(true) // This may trigger the permission dialog
+
+	results, err := keychain.QueryItem(query)
+	if err != nil {
+		logger.Printf("Failed to ensure keychain access: %s", err)
+		return err
+	}
+
+	if len(results) == 0 {
+		logger.Printf("No keychain entry found when ensuring access")
+		return errEmptyResults
+	}
+
+	logger.Printf("Successfully ensured keychain access permission")
+	return nil
 }
 
 // KeychainClient represents a single instance of a pinentry server
@@ -257,13 +288,23 @@ func (c KeychainClient) Msg(pinentry.Settings) *common.Error {
 // GetPIN executes the main logic for returning a password/pin back to the gpg-agent
 func GetPIN(authFn AuthFunc, promptFn PromptFunc, logger *log.Logger) GetPinFunc {
 	return func(s pinentry.Settings) (string, *common.Error) {
+		logger.Printf("GETPIN called with desc: %s", s.Desc)
 		matches := emailRegex.FindStringSubmatch(s.Desc)
 		name := ""
 		email := ""
 
 		if len(matches) > 2 {
-			name = strings.Split(matches[1], " <")[0]
+			// matches[1] contains the full string like "Name (comment) <email>"
+			// We need to extract just the name without the comment
+			fullName := strings.Split(matches[1], " <")[0]
+			// Remove any parenthetical comments
+			if idx := strings.Index(fullName, " ("); idx != -1 {
+				name = fullName[:idx]
+			} else {
+				name = fullName
+			}
 			email = matches[2]
+			logger.Printf("Parsed name: %s, email: %s", name, email)
 		}
 
 		keyID := ""
@@ -289,11 +330,13 @@ func GetPIN(authFn AuthFunc, promptFn PromptFunc, logger *log.Logger) GetPinFunc
 		}
 
 		keychainLabel := fmt.Sprintf("%s <%s> (%s)", name, email, keyID)
+		logger.Printf("Checking for keychain entry: %s", keychainLabel)
 		exists, err := checkEntryInKeychain(keychainLabel)
 		if err != nil {
 			logger.Printf("error checking entry in keychain: %s", err)
 			return "", assuanError(err)
 		}
+		logger.Printf("Keychain entry exists: %v", exists)
 
 		// If the entry is not found in the keychain, we trigger `pinentry-mac` with the option
 		// to save the pin in the keychain.
@@ -336,13 +379,29 @@ func GetPIN(authFn AuthFunc, promptFn PromptFunc, logger *log.Logger) GetPinFunc
 				err = storePasswordInKeychain(keychainLabel, keyInfo, pin)
 
 				if err == keychain.ErrorDuplicateItem {
-					logger.Printf("Duplicated entry in the keychain")
+					logger.Printf("Keychain entry already exists, will need permission on next access")
+					// Don't treat duplicate as fatal - the entry exists, we just need permission
+				} else if err != nil {
+					logger.Printf("Error storing password in keychain: %s", err)
 					return "", assuanError(err)
 				}
 			} else {
 				logger.Printf("The keychain entry was created by pinentry-mac. Permission will be required on next run.")
 			}
 
+			return string(pin), nil
+		}
+
+		// Entry exists - ensure we have permission to access it before Touch ID
+		logger.Printf("Keychain entry exists, ensuring access permission...")
+		if err := ensureKeychainAccess(keychainLabel, logger); err != nil {
+			logger.Printf("Cannot ensure keychain access, falling back to pinentry-mac: %s", err)
+			// Fall back to pinentry-mac if we can't get permission
+			pin, err := promptFn(s)
+			if err != nil {
+				logger.Printf("Error calling fallback pinentry program: %s", err)
+				return "", assuanError(err)
+			}
 			return string(pin), nil
 		}
 
@@ -359,7 +418,8 @@ func GetPIN(authFn AuthFunc, promptFn PromptFunc, logger *log.Logger) GetPinFunc
 
 		password, err := passwordFromKeychain(keychainLabel)
 		if err != nil {
-			log.Printf("Error fetching password from Keychain %s", err)
+			logger.Printf("Error fetching password from Keychain: %s", err)
+			return "", assuanError(err)
 		}
 
 		return password, nil
@@ -419,6 +479,110 @@ func fixPINBinary(oldPath string) error {
 	return nil
 }
 
+// getInfoHandler handles GETINFO commands
+func getInfoHandler(pipe io.ReadWriter, _ interface{}, params string) *common.Error {
+	if params == "" {
+		return &common.Error{
+			Src:     common.ErrSrcAssuan,
+			Code:    common.ErrAssInvValue,
+			SrcName: "assuan",
+			Message: "missing argument",
+		}
+	}
+
+	var data string
+	switch params {
+	case "flavor":
+		data = "touchid"
+	case "version":
+		data = version
+	case "pid":
+		data = strconv.Itoa(os.Getpid())
+	case "ttyinfo":
+		// ttyinfo := "<tty> <ownerpid> <term>"
+		ttyinfo := fmt.Sprintf("%s %d %s",
+			os.Getenv("GPG_TTY"),
+			os.Getppid(),
+			os.Getenv("TERM"))
+		data = strings.TrimSpace(ttyinfo)
+	default:
+		return &common.Error{
+			Src:     common.ErrSrcAssuan,
+			Code:    common.ErrNotFound,
+			SrcName: "assuan",
+			Message: "unknown value",
+		}
+	}
+
+	common.WriteData(pipe, []byte(data))
+	return nil
+}
+
+// serveWithCustomHandlers extends pinentry.Serve with custom command handlers
+func serveWithCustomHandlers(callbacks pinentry.Callbacks, greeting string) error {
+	info := pinentry.ProtoInfo
+	info.Greeting = greeting
+
+	// Add the GETINFO handler
+	info.Handlers["GETINFO"] = getInfoHandler
+
+	// Add the standard pinentry handlers
+	info.Handlers["GETPIN"] = func(pipe io.ReadWriter, state interface{}, _ string) *common.Error {
+		if callbacks.GetPIN == nil {
+			return &common.Error{
+				Src:     common.ErrSrcPinentry,
+				Code:    common.ErrNotImplemented,
+				SrcName: "pinentry",
+				Message: "GETPIN op is not supported",
+			}
+		}
+		pass, err := callbacks.GetPIN(*state.(*pinentry.Settings))
+		if err != nil {
+			return err
+		}
+		common.WriteData(pipe, []byte(pass))
+		return nil
+	}
+
+	info.Handlers["CONFIRM"] = func(pipe io.ReadWriter, state interface{}, _ string) *common.Error {
+		if callbacks.Confirm == nil {
+			return &common.Error{
+				Src:     common.ErrSrcPinentry,
+				Code:    common.ErrNotImplemented,
+				SrcName: "pinentry",
+				Message: "CONFIRM op is not supported",
+			}
+		}
+		v, err := callbacks.Confirm(*state.(*pinentry.Settings))
+		if err != nil {
+			return err
+		}
+		if !v {
+			return &common.Error{
+				Src:     common.ErrSrcPinentry,
+				Code:    common.ErrCanceled,
+				SrcName: "pinentry",
+				Message: "operation canceled",
+			}
+		}
+		return nil
+	}
+
+	info.Handlers["MESSAGE"] = func(pipe io.ReadWriter, state interface{}, _ string) *common.Error {
+		if callbacks.Msg == nil {
+			return &common.Error{
+				Src:     common.ErrSrcPinentry,
+				Code:    common.ErrNotImplemented,
+				SrcName: "pinentry",
+				Message: "MESSAGE op is not supported",
+			}
+		}
+		return callbacks.Msg(*state.(*pinentry.Settings))
+	}
+
+	return server.ServeStdin(info)
+}
+
 func main() {
 	flag.Parse()
 	if !sensor.IsTouchIDAvailable() {
@@ -472,7 +636,7 @@ func main() {
 		Msg:     client.Msg,
 	}
 
-	if err := pinentry.Serve(callbacks, "Hi from pinentry-touchid!"); err != nil && err != io.EOF {
+	if err := serveWithCustomHandlers(callbacks, "Hi from pinentry-touchid!"); err != nil && err != io.EOF {
 		fmt.Fprintf(os.Stderr, "Pinentry Serve returned error: %v\n", err)
 		os.Exit(-1)
 	}

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ var (
 
 	check      = flag.Bool("check", false, "Verify that pinentry-mac is present in the system.")
 	fixSymlink = flag.Bool("fix", false, "Set up pinentry-mac as the fallback PIN entry program.")
+	selfTest   = flag.Bool("self-test", false, "Run startup diagnostics and report status.")
 	_          = flag.String("display", "", "Set the X display (unused)")
 )
 
@@ -133,18 +134,20 @@ func New() KeychainClient {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		file, err := os.Create(path)
 		if err != nil {
-			panic("Couldn't create log file")
+			logger = log.New(os.Stderr, "pinentry-touchid: ", defaultLoggerFlags)
+			logger.Printf("Warning: could not create log file %s: %v, logging to stderr", path, err)
+		} else {
+			logger = log.New(file, "", defaultLoggerFlags)
 		}
-
-		logger = log.New(file, "", defaultLoggerFlags)
 	} else {
 		// append to the existing log file
 		file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 		if err != nil {
-			panic(err)
+			logger = log.New(os.Stderr, "pinentry-touchid: ", defaultLoggerFlags)
+			logger.Printf("Warning: could not open log file %s: %v, logging to stderr", path, err)
+		} else {
+			logger = log.New(file, "", defaultLoggerFlags)
 		}
-
-		logger = log.New(file, "", defaultLoggerFlags)
 	}
 
 	logger.Print("Ready!")
@@ -601,6 +604,47 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Pinentry Serve returned error: %v\n", err)
 			os.Exit(-1)
 		}
+		return
+	}
+
+	if *selfTest {
+		ok := true
+
+		// Check Touch ID
+		if sensor.IsTouchIDAvailable() {
+			fmt.Fprintf(os.Stdout, "Touch ID:    available\n")
+		} else {
+			fmt.Fprintf(os.Stdout, "Touch ID:    unavailable\n")
+			ok = false
+		}
+
+		// Check log file writability
+		logPath := filepath.Clean(DefaultLogLocation)
+		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+		if err != nil {
+			fmt.Fprintf(os.Stdout, "Log file:    %s (not writable: %v)\n", logPath, err)
+			ok = false
+		} else {
+			f.Close()
+			fmt.Fprintf(os.Stdout, "Log file:    %s (writable)\n", logPath)
+		}
+
+		// Check fallback pinentry binary
+		fallbackPath, err := validatePINBinary()
+		if err != nil {
+			fmt.Fprintf(os.Stdout, "Fallback:    %s (%v)\n", fallbackPath, err)
+			ok = false
+		} else {
+			fmt.Fprintf(os.Stdout, "Fallback:    %s\n", fallbackPath)
+		}
+
+		// Version
+		fmt.Fprintf(os.Stdout, "Version:     %s\n", version)
+
+		if !ok {
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 
 	if *fixSymlink {

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/foxcpp/go-assuan/pinentry"
 	"github.com/foxcpp/go-assuan/server"
 	pinentryBinary "github.com/gopasspw/pinentry"
-	"github.com/jorgelbg/pinentry-touchid/sensor"
+	"github.com/lujstn/pinentry-touchid/sensor"
 	"github.com/keybase/go-keychain"
 	touchid "github.com/lox/go-touchid"
 )

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/foxcpp/go-assuan/pinentry"
 	"github.com/foxcpp/go-assuan/server"
 	pinentryBinary "github.com/gopasspw/pinentry"
-	"github.com/lujstn/pinentry-touchid/sensor"
+	"github.com/jorgelbg/pinentry-touchid/sensor"
 	"github.com/keybase/go-keychain"
 	touchid "github.com/lox/go-touchid"
 )

--- a/pinentry_test.go
+++ b/pinentry_test.go
@@ -5,10 +5,15 @@
 package main
 
 import (
+	"bytes"
 	"io/ioutil"
 	"log"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/foxcpp/go-assuan/common"
 	"github.com/foxcpp/go-assuan/pinentry"
 	"github.com/keybase/go-keychain"
 )
@@ -166,4 +171,76 @@ func cleanKeychain(label string) error {
 	query.SetReturnData(true)
 
 	return keychain.DeleteItem(query)
+}
+
+func TestGetInfoHandler(t *testing.T) {
+	tests := []struct {
+		name      string
+		params    string
+		wantData  string
+		wantError bool
+		errorCode int
+	}{
+		{
+			name:      "flavor",
+			params:    "flavor",
+			wantData:  "touchid",
+			wantError: false,
+		},
+		{
+			name:      "version",
+			params:    "version", 
+			wantData:  version,
+			wantError: false,
+		},
+		{
+			name:      "pid",
+			params:    "pid",
+			wantData:  strconv.Itoa(os.Getpid()),
+			wantError: false,
+		},
+		{
+			name:      "ttyinfo",
+			params:    "ttyinfo",
+			wantData:  strings.TrimSpace(os.Getenv("GPG_TTY") + " " + strconv.Itoa(os.Getppid()) + " " + os.Getenv("TERM")),
+			wantError: false,
+		},
+		{
+			name:      "unknown",
+			params:    "unknown",
+			wantError: true,
+			errorCode: int(common.ErrNotFound),
+		},
+		{
+			name:      "empty",
+			params:    "",
+			wantError: true,
+			errorCode: int(common.ErrAssInvValue),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := getInfoHandler(&buf, nil, tt.params)
+
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				} else if int(err.Code) != tt.errorCode {
+					t.Errorf("expected error code %d but got %d", tt.errorCode, int(err.Code))
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				
+				// Check that data was written
+				output := buf.String()
+				if !strings.Contains(output, tt.wantData) {
+					t.Errorf("expected output to contain %q but got %q", tt.wantData, output)
+				}
+			}
+		})
+	}
 }

--- a/pinentry_test.go
+++ b/pinentry_test.go
@@ -6,9 +6,11 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -171,6 +173,40 @@ func cleanKeychain(label string) error {
 	query.SetReturnData(true)
 
 	return keychain.DeleteItem(query)
+}
+
+func TestWithLoggerDoesNotPanic(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	client := WithLogger(logger)
+	if client.logger == nil {
+		t.Fatal("expected logger to be set")
+	}
+}
+
+func TestNewGracefulLogFileHandling(t *testing.T) {
+	// Save and restore DefaultLogLocation
+	origLocation := DefaultLogLocation
+	defer func() { DefaultLogLocation = origLocation }()
+
+	// Point to an unwritable path
+	dir := t.TempDir()
+	unwritable := filepath.Join(dir, "noperm")
+	if err := os.Mkdir(unwritable, 0000); err != nil {
+		t.Fatalf("failed to create unwritable dir: %v", err)
+	}
+	DefaultLogLocation = filepath.Join(unwritable, "test.log")
+
+	// New() should not panic — it should fall back to stderr
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("New() panicked when log file is unwritable: %v", r)
+		}
+	}()
+
+	client := New()
+	if client.logger == nil {
+		t.Fatal("expected logger to be set even with unwritable log path")
+	}
 }
 
 func TestGetInfoHandler(t *testing.T) {


### PR DESCRIPTION
This commit implements critical fixes to make pinentry-touchid compatible with modern GnuPG versions (2.4+) and resolves keychain access permission issues.

## Key Changes

### 1. GETINFO Command Support
- Implemented GETINFO handler for commands required by GnuPG 2.4+
- Added support for: flavor, version, pid, and ttyinfo queries
- Resolves "You may want to update to a newer pinentry" errors

### 2. Keychain Permission Handling
- Added ensureKeychainAccess() function to properly handle macOS permission dialogs
- Fixed flow to check keychain permissions before Touch ID authentication
- Ensures pinentry-touchid can access entries created by pinentry-mac

### 3. Name Parsing Fix
- Fixed regex parsing to correctly extract user names from GPG descriptions
- Strips GPG key comments (e.g., "GPG Key generated...") from names
- Ensures keychain entry labels match between pinentry-mac and pinentry-touchid

### 4. Duplicate Entry Handling
- Changed duplicate keychain entry errors from fatal to non-fatal
- Allows the authentication flow to continue when entries already exist
- Improves robustness when switching between pinentry programs

## Technical Details

The main issue was that GnuPG 2.4+ requires pinentry programs to respond to GETINFO queries during initialization. Without these handlers, gpg-agent would abort the connection immediately after the handshake.

Additionally, when keychain entries are created by pinentry-mac, macOS requires explicit permission for pinentry-touchid to access them. The new flow ensures these permissions are granted before attempting Touch ID authentication.

## Testing

- Added comprehensive unit tests for GETINFO commands
- Verified compatibility with GnuPG 2.4.8 on macOS
- Tested keychain permission flow with existing entries
- All existing tests continue to pass

Fixes #9, #17, #42